### PR TITLE
zendeskメッセージングのサンプルを作成

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,11 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script
+      type="text/javascript"
+      id="ze-snippet"
+      src="https://static.zdassets.com/ekr/snippet.js?key=bc5d3d8f-b82c-4eb8-aade-49bf2725ead3"
+    ></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,9 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import "./App.css";
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>zendeskサンプル</h1>
     </div>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
概要
---
メッセージングのサンプルを作成
現状はindex.tsxのbody下に直接scriptを埋め込んでいるため、
後ほどchat表示をコンポーネントとして作成するように修正する

スクリーンショット
---
<img width="865" alt="スクリーンショット 2023-01-18 19 42 26" src="https://user-images.githubusercontent.com/63906011/213151189-74f4b93f-1aca-49fd-92bf-16cef0c077cd.png">
<img width="864" alt="スクリーンショット 2023-01-18 19 42 32" src="https://user-images.githubusercontent.com/63906011/213151202-e5d88da7-bb38-4a05-8a42-16092bdc370d.png">
